### PR TITLE
Fix model picker pushing send button off screen

### DIFF
--- a/app/src/main/java/space/httpjames/kagiassistantmaterial/ui/message/MessageCenter.kt
+++ b/app/src/main/java/space/httpjames/kagiassistantmaterial/ui/message/MessageCenter.kt
@@ -234,7 +234,8 @@ fun MessageCenter(
                         viewModel.openModelBottomSheet()
                         haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                     },
-                    contentPadding = PaddingValues(horizontal = 16.dp)
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    modifier = Modifier.weight(1f, fill = false)
                 ) {
                     Text(
                         text = viewModel.getProfile()?.name?.replace("(preview)", "")?.trim()


### PR DESCRIPTION
Adds weight to model picker button to prevent pushing send button out of frame with longer model names (especially on smaller devices)

<img src="https://github.com/user-attachments/assets/5e0c8e7f-458e-45d7-be88-d2113e3a7d8f"  width="30%">